### PR TITLE
fix: add request timeout

### DIFF
--- a/app_authentication.py
+++ b/app_authentication.py
@@ -41,6 +41,7 @@ if __name__ == '__main__':
         get_installation_token_url,
         headers=call_headers,
         auth=BearerAuth(encoded_jwt),
+        timeout=15,
     )
 
     token = get_installation_token_response.json()["token"]


### PR DESCRIPTION
This PR adds a 15 second timeout to the request to get an app token. This follows a failure scenario in a flow where this action was used when the workflow blocked for 6hrs until it timed out itself on this action after a request timeout from GitHub. 

Implemented in v2 [#3](https://github.com/Flutter-Tech/github-app-token/pull/3)