### PR TITLE
ci: test sonarcloud fail

### DIFF
--- a/app_authentication.py
+++ b/app_authentication.py
@@ -47,3 +47,7 @@ if __name__ == '__main__':
 
     print(f"::add-mask::{token}")
     print(f"::set-output name=app_token::{token}")
+
+    # this useless block of code should trigger a sonarcloud quality fail
+    for i in range(3):
+        pass


### PR DESCRIPTION
This PR adds a useless piece of code to the action and should trigger a quality check fail in sonarcloud which will then block the merge. 